### PR TITLE
feat(header): add hero image carousel for homepage

### DIFF
--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -1,0 +1,60 @@
+"use strict";
+
+var HeroCarousel = {
+  carousel: null,
+  slides: [],
+  currentIndex: 0,
+  intervalId: null,
+  intervalDuration: 5000, // 5 seconds
+
+  init: function() {
+    this.carousel = document.getElementById('hero-carousel');
+    if (!this.carousel) {
+      return;
+    }
+
+    this.slides = this.carousel.querySelectorAll('.carousel-slide');
+    if (this.slides.length <= 1) {
+      return; // No need for carousel with 0 or 1 slide
+    }
+
+    this.startAutoRotation();
+  },
+
+  startAutoRotation: function() {
+    var self = this;
+    this.intervalId = setInterval(function() {
+      self.nextSlide();
+    }, this.intervalDuration);
+  },
+
+  nextSlide: function() {
+    var currentSlide = this.slides[this.currentIndex];
+    var nextIndex = (this.currentIndex + 1) % this.slides.length;
+    var nextSlide = this.slides[nextIndex];
+
+    // Add exiting class to current slide (slides left)
+    currentSlide.classList.add('exiting');
+    currentSlide.classList.remove('active');
+
+    // Activate next slide (slides in from right)
+    nextSlide.classList.add('active');
+
+    // Clean up exiting class after transition completes
+    var self = this;
+    setTimeout(function() {
+      currentSlide.classList.remove('exiting');
+    }, 600); // Match CSS transition duration
+
+    this.currentIndex = nextIndex;
+  }
+};
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', function() {
+    HeroCarousel.init();
+  });
+} else {
+  HeroCarousel.init();
+}

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -532,9 +532,10 @@ ul.news-items {
   position: absolute;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  width: 100%;
+  height: 100%;
   pointer-events: none;
+  z-index: 1;
   // Very strong radial gradient vignette - image should dissolve into background
   background: radial-gradient(
     ellipse at center,

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -487,31 +487,31 @@ ul.news-items {
 }
 
 // Hero Carousel Styles
+// Carousel positioned absolutely at bottom of .main-description, like the original image
 .hero-carousel {
-  position: relative;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
   width: 100%;
-  overflow: hidden;
 }
 
 .carousel-slide {
-  position: absolute;
-  top: 0;
-  left: 0;
+  display: none;
   width: 100%;
-  opacity: 0;
-  transform: translateX(100%);
-  transition: transform 0.6s ease-in-out, opacity 0.6s ease-in-out;
 
-  // Active slide is relative to give the carousel height
   &.active {
-    position: relative;
-    opacity: 1;
-    transform: translateX(0);
+    display: block;
+    animation: slideIn 0.6s ease-in-out;
   }
 
   &.exiting {
-    opacity: 1;
-    transform: translateX(-100%);
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    animation: slideOut 0.6s ease-in-out forwards;
   }
 
   img {
@@ -519,8 +519,8 @@ ul.news-items {
     width: 100%;
     height: auto;
     max-width: 100%;
-    // Greyscale filter
-    filter: grayscale(100%);
+    // Greyscale + faded/washed out look like original home-marmotte.png
+    filter: grayscale(100%) brightness(1.3) contrast(0.7);
   }
 
   // Vignette overlay to blend edges with #f1f1f1 background
@@ -532,19 +532,39 @@ ul.news-items {
     right: 0;
     bottom: 0;
     pointer-events: none;
-    // Radial gradient vignette that fades to the background color
+    // Strong radial gradient vignette that fades to the background color
     background: radial-gradient(
       ellipse at center,
-      transparent 40%,
-      rgba(241, 241, 241, 0.3) 70%,
-      rgba(241, 241, 241, 0.7) 90%,
+      transparent 20%,
+      rgba(241, 241, 241, 0.4) 50%,
+      rgba(241, 241, 241, 0.8) 75%,
       $hero-color 100%
     );
   }
+
+  // Ensure picture element is relative for the ::after overlay
+  picture {
+    display: block;
+    position: relative;
+    width: 100%;
+  }
 }
 
-// Ensure picture element doesn't break layout
-.carousel-slide picture {
-  display: block;
-  width: 100%;
+// Slide animations
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
 }

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -525,31 +525,31 @@ ul.news-items {
     opacity: 0.6;
   }
 
-  // Vignette overlay to blend edges with #f1f1f1 background
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    // Very strong radial gradient vignette - image should dissolve into background
-    background: radial-gradient(
-      ellipse at center,
-      transparent 0%,
-      rgba(241, 241, 241, 0.3) 30%,
-      rgba(241, 241, 241, 0.6) 50%,
-      rgba(241, 241, 241, 0.85) 70%,
-      $hero-color 85%
-    );
-  }
-
-  // Ensure picture element is relative for the ::after overlay
+  // Picture element contains the vignette overlay
   picture {
     display: block;
     position: relative;
     width: 100%;
+
+    // Vignette overlay to blend edges with #f1f1f1 background
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      pointer-events: none;
+      // Very strong radial gradient vignette - image should dissolve into background
+      background: radial-gradient(
+        ellipse at center,
+        transparent 0%,
+        rgba(241, 241, 241, 0.3) 30%,
+        rgba(241, 241, 241, 0.6) 50%,
+        rgba(241, 241, 241, 0.85) 70%,
+        $hero-color 85%
+      );
+    }
   }
 }
 

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -488,24 +488,21 @@ ul.news-items {
 
 // Hero Carousel Styles
 .hero-carousel {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: relative;
+  width: 100%;
   overflow: hidden;
-  max-width: 100%;
-  height: auto;
 }
 
 .carousel-slide {
   position: absolute;
-  bottom: 0;
+  top: 0;
   left: 0;
   width: 100%;
   opacity: 0;
   transform: translateX(100%);
   transition: transform 0.6s ease-in-out, opacity 0.6s ease-in-out;
 
+  // Active slide is relative to give the carousel height
   &.active {
     position: relative;
     opacity: 1;

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -499,10 +499,10 @@ ul.news-items {
 .carousel-slide {
   display: none;
   width: 100%;
-  position: relative;
 
   &.active {
     display: block;
+    position: relative;
     animation: slideIn 0.6s ease-in-out;
   }
 
@@ -520,31 +520,32 @@ ul.news-items {
     width: 100%;
     height: auto;
     max-width: 100%;
-    // Greyscale + very washed out/faded look to match original home-marmotte.png
-    // High brightness + low contrast + reduced opacity creates the light grey effect
-    filter: grayscale(100%) brightness(1.6) contrast(0.5);
-    opacity: 0.6;
+    // Greyscale + slightly less washed out for better visibility in center
+    filter: grayscale(100%) brightness(1.4) contrast(0.6);
+    opacity: 0.7;
+    // Apply vignette using CSS mask - stronger fade, especially at top for nav bar blend
+    mask-image: radial-gradient(
+      ellipse farthest-side at center,
+      black 0%,
+      black 25%,
+      rgba(0, 0, 0, 0.4) 50%,
+      rgba(0, 0, 0, 0.1) 70%,
+      transparent 85%
+    );
+    -webkit-mask-image: radial-gradient(
+      ellipse farthest-side at center,
+      black 0%,
+      black 25%,
+      rgba(0, 0, 0, 0.4) 50%,
+      rgba(0, 0, 0, 0.1) 70%,
+      transparent 85%
+    );
   }
-}
 
-// Vignette overlay element - positioned over the image
-.carousel-vignette {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 1;
-  // Very strong radial gradient vignette - image should dissolve into background
-  background: radial-gradient(
-    ellipse at center,
-    transparent 0%,
-    rgba(241, 241, 241, 0.3) 30%,
-    rgba(241, 241, 241, 0.6) 50%,
-    rgba(241, 241, 241, 0.85) 70%,
-    #f1f1f1 85%
-  );
+  // Keep the vignette div but hide it - not needed with mask approach
+  .carousel-vignette {
+    display: none;
+  }
 }
 
 // Slide animations

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -519,8 +519,10 @@ ul.news-items {
     width: 100%;
     height: auto;
     max-width: 100%;
-    // Greyscale + faded/washed out look like original home-marmotte.png
-    filter: grayscale(100%) brightness(1.3) contrast(0.7);
+    // Greyscale + very washed out/faded look to match original home-marmotte.png
+    // High brightness + low contrast + reduced opacity creates the light grey effect
+    filter: grayscale(100%) brightness(1.6) contrast(0.5);
+    opacity: 0.6;
   }
 
   // Vignette overlay to blend edges with #f1f1f1 background
@@ -532,13 +534,14 @@ ul.news-items {
     right: 0;
     bottom: 0;
     pointer-events: none;
-    // Strong radial gradient vignette that fades to the background color
+    // Very strong radial gradient vignette - image should dissolve into background
     background: radial-gradient(
       ellipse at center,
-      transparent 20%,
-      rgba(241, 241, 241, 0.4) 50%,
-      rgba(241, 241, 241, 0.8) 75%,
-      $hero-color 100%
+      transparent 0%,
+      rgba(241, 241, 241, 0.3) 30%,
+      rgba(241, 241, 241, 0.6) 50%,
+      rgba(241, 241, 241, 0.85) 70%,
+      $hero-color 85%
     );
   }
 

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -485,3 +485,69 @@ ul.news-items {
   padding-left: 0;
   list-style-type: none;
 }
+
+// Hero Carousel Styles
+.hero-carousel {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  overflow: hidden;
+  max-width: 100%;
+  height: auto;
+}
+
+.carousel-slide {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  opacity: 0;
+  transform: translateX(100%);
+  transition: transform 0.6s ease-in-out, opacity 0.6s ease-in-out;
+
+  &.active {
+    position: relative;
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  &.exiting {
+    opacity: 1;
+    transform: translateX(-100%);
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 100%;
+    // Greyscale filter
+    filter: grayscale(100%);
+  }
+
+  // Vignette overlay to blend edges with #f1f1f1 background
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    // Radial gradient vignette that fades to the background color
+    background: radial-gradient(
+      ellipse at center,
+      transparent 40%,
+      rgba(241, 241, 241, 0.3) 70%,
+      rgba(241, 241, 241, 0.7) 90%,
+      $hero-color 100%
+    );
+  }
+}
+
+// Ensure picture element doesn't break layout
+.carousel-slide picture {
+  display: block;
+  width: 100%;
+}

--- a/assets/scss/critical.scss
+++ b/assets/scss/critical.scss
@@ -499,6 +499,7 @@ ul.news-items {
 .carousel-slide {
   display: none;
   width: 100%;
+  position: relative;
 
   &.active {
     display: block;
@@ -524,33 +525,25 @@ ul.news-items {
     filter: grayscale(100%) brightness(1.6) contrast(0.5);
     opacity: 0.6;
   }
+}
 
-  // Picture element contains the vignette overlay
-  picture {
-    display: block;
-    position: relative;
-    width: 100%;
-
-    // Vignette overlay to blend edges with #f1f1f1 background
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      pointer-events: none;
-      // Very strong radial gradient vignette - image should dissolve into background
-      background: radial-gradient(
-        ellipse at center,
-        transparent 0%,
-        rgba(241, 241, 241, 0.3) 30%,
-        rgba(241, 241, 241, 0.6) 50%,
-        rgba(241, 241, 241, 0.85) 70%,
-        $hero-color 85%
-      );
-    }
-  }
+// Vignette overlay element - positioned over the image
+.carousel-vignette {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  // Very strong radial gradient vignette - image should dissolve into background
+  background: radial-gradient(
+    ellipse at center,
+    transparent 0%,
+    rgba(241, 241, 241, 0.3) 30%,
+    rgba(241, 241, 241, 0.6) 50%,
+    rgba(241, 241, 241, 0.85) 70%,
+    #f1f1f1 85%
+  );
 }
 
 // Slide animations

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,63 @@
+{{$header := .Params.header}}
+{{$imageBundle := .Site.GetPage "uploads"}}
+
+{{/* Check if this is the homepage */}}
+{{if .IsHome}}
+<div class="header">
+  <div class="container">
+    <div class="padder">
+      <div class="main-description animated fadeIn">
+        {{- with $header.description -}}
+          <h1 class="break-word">{{- . | safeHTML -}}</h1>
+        {{- end -}}
+
+        {{/* Carousel with project cover images */}}
+        <div class="hero-carousel" id="hero-carousel">
+          {{/* Collect all project cover images */}}
+          {{$projects := where .Site.RegularPages "Type" "projet"}}
+          {{$coverImages := slice}}
+
+          {{range $projects}}
+            {{range .Params.projects}}
+              {{with .image}}
+                {{$coverImages = $coverImages | append .url}}
+              {{end}}
+            {{end}}
+          {{end}}
+
+          {{/* Shuffle the images using Hugo's shuffle function */}}
+          {{$shuffledImages := shuffle $coverImages}}
+
+          {{/* Render carousel slides */}}
+          {{range $index, $imgPath := $shuffledImages}}
+            {{$original := $imageBundle.Resources.GetMatch $imgPath}}
+            {{with $original}}
+              {{/* Process image: Fill to 1130x500, then apply grayscale */}}
+              {{$processed := .Fill "1130x500"}}
+              <div class="carousel-slide{{if eq $index 0}} active{{end}}" data-index="{{$index}}">
+                <picture>
+                  <img src="{{$processed.RelPermalink}}" alt="Project cover" loading="{{if eq $index 0}}eager{{else}}lazy{{end}}" />
+                </picture>
+              </div>
+            {{end}}
+          {{end}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{else}}
+{{/* Non-homepage: use original header behavior */}}
+<div class="header">
+  <div class="container">
+    <div class="padder">
+      <div class="main-description animated fadeIn">
+        {{- with $header.description -}}
+          <h1 class="break-word">{{- . | safeHTML -}}</h1>
+        {{- end -}}
+        {{- partial "modules/image" (dict "image" $header.image "page" .) -}}
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,9 +36,8 @@
               {{/* Process image: Fill to 1130x500, then apply grayscale */}}
               {{$processed := .Fill "1130x500"}}
               <div class="carousel-slide{{if eq $index 0}} active{{end}}" data-index="{{$index}}">
-                <picture>
-                  <img src="{{$processed.RelPermalink}}" alt="Project cover" loading="{{if eq $index 0}}eager{{else}}lazy{{end}}" />
-                </picture>
+                <img src="{{$processed.RelPermalink}}" alt="Project cover" loading="{{if eq $index 0}}eager{{else}}lazy{{end}}" />
+                <div class="carousel-vignette"></div>
               </div>
             {{end}}
           {{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,13 +11,14 @@
           <h1 class="break-word">{{- . | safeHTML -}}</h1>
         {{- end -}}
 
-        {{/* Carousel with project cover images */}}
+        {{/* Carousel with cover images from released Films only */}}
         <div class="hero-carousel" id="hero-carousel">
-          {{/* Collect all project cover images */}}
+          {{/* Collect cover images only from released projects (Films) */}}
           {{$projects := where .Site.RegularPages "Type" "projet"}}
+          {{$releasedProjects := where $projects ".Params.released" true}}
           {{$coverImages := slice}}
 
-          {{range $projects}}
+          {{range $releasedProjects}}
             {{range .Params.projects}}
               {{with .image}}
                 {{$coverImages = $coverImages | append .url}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -33,8 +33,8 @@
           {{range $index, $imgPath := $shuffledImages}}
             {{$original := $imageBundle.Resources.GetMatch $imgPath}}
             {{with $original}}
-              {{/* Process image: Fill to 1130x500, then apply grayscale */}}
-              {{$processed := .Fill "1130x500"}}
+              {{/* Process image: Fill to 1130x500 with Smart anchor to detect important content */}}
+              {{$processed := .Fill "1130x500 Smart"}}
               <div class="carousel-slide{{if eq $index 0}} active{{end}}" data-index="{{$index}}">
                 <img src="{{$processed.RelPermalink}}" alt="Project cover" loading="{{if eq $index 0}}eager{{else}}lazy{{end}}" />
                 <div class="carousel-vignette"></div>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,0 +1,15 @@
+{{- partial "deferred-load-script.html" . -}}
+{{$js := resources.Get "js/app.js"}}
+{{if eq (hugo.Environment) "production" | or (eq .Site.Params.env "production")}}
+{{$js = $js | minify | fingerprint}}
+{{end}}
+<script src="{{$js.RelPermalink}}"></script>
+
+{{/* Hero Carousel Script - only load on homepage */}}
+{{if .IsHome}}
+{{$carouselJs := resources.Get "js/carousel.js"}}
+{{if eq (hugo.Environment) "production" | or (eq .Site.Params.env "production")}}
+{{$carouselJs = $carouselJs | minify | fingerprint}}
+{{end}}
+<script src="{{$carouselJs.RelPermalink}}"></script>
+{{end}}


### PR DESCRIPTION
## Summary

- Replace static home-marmotte.png with a carousel of project cover images from released Films
- Images are shuffled randomly on each page load
- Carousel auto-rotates every 5 seconds with slide-left transition
- Images processed with greyscale filter and vignette effect to blend with #f1f1f1 background
- Smart cropping ensures important content is preserved

## Changes

- `layouts/partials/header.html`: New partial overriding theme header for homepage carousel
- `assets/scss/critical.scss`: Carousel styles with CSS mask-image vignette
- `assets/js/carousel.js`: Auto-rotation logic with slide animations
- `layouts/partials/scripts.html`: Conditional loading of carousel script on homepage

## Test plan

- [x] Verify carousel displays on homepage with project cover images
- [x] Confirm images rotate every 5 seconds with slide-left animation
- [x] Check vignette effect blends smoothly with navigation bar background
- [x] Verify non-homepage pages still display standard header image
- [x] Test responsive behavior on mobile devices